### PR TITLE
Remove "Coq" prefix in Python class names and change coq- to alectryon- in CSS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,5 +5,6 @@
 Version 1.1
 ===========
 
+- Rename CSS classes from ``.coq-…`` to ``.alectryon-…``.
 - Rename CSS class ``alectryon-header`` to ``alectryon-banner``.
 - Remove the undocumented ``alectryon-header`` directive.

--- a/alectryon/html.py
+++ b/alectryon/html.py
@@ -24,7 +24,7 @@ import shutil
 
 from dominate import tags
 
-from .core import CoqText, RichSentence, CoqGoals, CoqMessages
+from .core import Text, RichSentence, Goals, Messages
 from . import transforms, GENERATOR
 
 _SELF_PATH = path.dirname(path.realpath(__file__))
@@ -111,7 +111,7 @@ class HtmlGenerator:
 
     def gen_goal(self, goal, toggle=None):
         """Serialize a goal to HTML."""
-        with tags.blockquote(cls="coq-goal"):
+        with tags.blockquote(cls="alectryon-goal"):
             if goal.hypotheses:
                 # Chrome doesn't support the ‘gap’ property in flex containers,
                 # so properly spacing hypotheses requires giving them margins
@@ -120,7 +120,7 @@ class HtmlGenerator:
                 # there are none.
                 self.gen_hyps(goal.hypotheses)
             toggle = goal.hypotheses and toggle
-            cls = "goal-separator" + (" coq-extra-goal-label" if toggle else "")
+            cls = "goal-separator" + (" alectryon-extra-goal-label" if toggle else "")
             with self.gen_label(toggle, cls):
                 tags.hr()
                 if goal.name:
@@ -138,45 +138,45 @@ class HtmlGenerator:
     def gen_goals(self, first, more):
         self.gen_goal(first)
         if more:
-            with tags.div(cls='coq-extra-goals'):
+            with tags.div(cls='alectryon-extra-goals'):
                 for goal in more:
-                    nm = self.gen_checkbox(False, "coq-extra-goal-toggle")
+                    nm = self.gen_checkbox(False, "alectryon-extra-goal-toggle")
                     self.gen_goal(goal, toggle=nm)
 
     def gen_input_toggle(self, fr):
         if not fr.outputs:
             return None
-        return self.gen_checkbox(fr.annots.unfold, "coq-toggle")
+        return self.gen_checkbox(fr.annots.unfold, "alectryon-toggle")
 
     def gen_input(self, fr, toggle):
-        cls = "coq-input" + (" alectryon-failed" if fr.annots.fails else "")
+        cls = "alectryon-input" + (" alectryon-failed" if fr.annots.fails else "")
         self.gen_label(toggle, cls, self.highlight(fr.contents))
 
     def gen_output(self, fr):
         # Using <small> improves rendering in RSS feeds
-        wrapper = tags.div(cls="coq-output-sticky-wrapper")
-        with tags.small(cls="coq-output").add(wrapper):
+        wrapper = tags.div(cls="alectryon-output-sticky-wrapper")
+        with tags.small(cls="alectryon-output").add(wrapper):
             for output in fr.outputs:
-                if isinstance(output, CoqMessages):
+                if isinstance(output, Messages):
                     assert output.messages, "transforms.commit_io_annotations"
-                    with tags.div(cls="coq-messages"):
+                    with tags.div(cls="alectryon-messages"):
                         for message in output.messages:
                             tags.blockquote(self.highlight(message.contents),
-                                            cls="coq-message")
-                if isinstance(output, CoqGoals):
+                                            cls="alectryon-message")
+                if isinstance(output, Goals):
                     assert output.goals, "transforms.commit_io_annotations"
-                    with tags.div(cls="coq-goals"):
+                    with tags.div(cls="alectryon-goals"):
                         self.gen_goals(output.goals[0], output.goals[1:])
 
     @staticmethod
     def gen_whitespace(wsps):
         for wsp in wsps:
-            tags.span(wsp, cls="coq-wsp")
+            tags.span(wsp, cls="alectryon-wsp")
 
     def gen_sentence(self, fr):
         if fr.contents is not None:
             self.gen_whitespace(fr.prefixes)
-        with tags.span(cls="coq-sentence"):
+        with tags.span(cls="alectryon-sentence"):
             toggle = self.gen_input_toggle(fr)
             if fr.contents is not None:
                 self.gen_input(fr, toggle)
@@ -186,8 +186,8 @@ class HtmlGenerator:
                 self.gen_whitespace(fr.suffixes)
 
     def gen_fragment(self, fr):
-        if isinstance(fr, CoqText):
-            tags.span(self.highlight(fr.contents), cls="coq-wsp")
+        if isinstance(fr, Text):
+            tags.span(self.highlight(fr.contents), cls="alectryon-wsp")
         else:
             assert isinstance(fr, RichSentence)
             self.gen_sentence(fr)

--- a/alectryon/json.py
+++ b/alectryon/json.py
@@ -24,29 +24,29 @@ from itertools import zip_longest
 
 from . import core
 
-COQ_TYPE_OF_ALIASES = {
-    "text": core.CoqText,
-    "hypothesis": core.CoqHypothesis,
-    "goal": core.CoqGoal,
-    "message": core.CoqMessage,
-    "sentence": core.CoqSentence,
-    "goals": core.CoqGoals,
-    "messages": core.CoqMessages,
+TYPE_OF_ALIASES = {
+    "text": core.Text,
+    "hypothesis": core.Hypothesis,
+    "goal": core.Goal,
+    "message": core.Message,
+    "sentence": core.Sentence,
+    "goals": core.Goals,
+    "messages": core.Messages,
     "rich_sentence": core.RichSentence,
 }
 
-ALIASES_OF_COQ_TYPE = {
-    cls.__name__: alias for (alias, cls) in COQ_TYPE_OF_ALIASES.items()
+ALIASES_OF_TYPE = {
+    cls.__name__: alias for (alias, cls) in TYPE_OF_ALIASES.items()
 }
 
-COQ_TYPES = list(COQ_TYPE_OF_ALIASES.values())
+TYPES = list(TYPE_OF_ALIASES.values())
 
 def json_of_annotated(obj):
     if isinstance(obj, list):
         return [json_of_annotated(x) for x in obj]
     if isinstance(obj, dict):
         return {k: json_of_annotated(v) for k, v in obj.items()}
-    type_name = ALIASES_OF_COQ_TYPE.get(type(obj).__name__)
+    type_name = ALIASES_OF_TYPE.get(type(obj).__name__)
     if type_name:
         d = {"_type": type_name}
         for k, v in zip(obj._fields, obj):
@@ -60,9 +60,9 @@ def minimal_json_of_annotated(obj):
         return [minimal_json_of_annotated(x) for x in obj]
     if isinstance(obj, dict):
         return {k: minimal_json_of_annotated(v) for k, v in obj.items()}
-    type_name = ALIASES_OF_COQ_TYPE.get(type(obj).__name__)
+    type_name = ALIASES_OF_TYPE.get(type(obj).__name__)
     if type_name:
-        if isinstance(obj, core.CoqText):
+        if isinstance(obj, core.Text):
             return obj.contents
         d = {k: minimal_json_of_annotated(v) for k, v in zip(obj._fields, obj)}
         contents = d.pop("contents", None)
@@ -77,12 +77,12 @@ def annotated_of_json(js):
         return [annotated_of_json(x) for x in js]
     if isinstance(js, dict):
         type_name = js.get("_type")
-        type_constr = COQ_TYPE_OF_ALIASES.get(type_name)
-        coq = {k: annotated_of_json(v) for k, v in js.items()}
+        type_constr = TYPE_OF_ALIASES.get(type_name)
+        obj = {k: annotated_of_json(v) for k, v in js.items()}
         if type_constr:
-            del coq["_type"]
-            return type_constr(**coq)
-        return coq
+            del obj["_type"]
+            return type_constr(**obj)
+        return obj
     return js
 
 def validate_inputs(annotated, reference):
@@ -92,7 +92,7 @@ def validate_inputs(annotated, reference):
             return False
         return all(validate_inputs(*p) for p in zip_longest(annotated, reference))
     # pylint: disable=isinstance-second-argument-not-valid-type
-    if isinstance(annotated, COQ_TYPES):
+    if isinstance(annotated, TYPES):
         if annotated.contents != reference:
             print(f"Mismatch: {annotated.contents} {reference}")
         return annotated.contents == reference

--- a/alectryon/latex.py
+++ b/alectryon/latex.py
@@ -20,7 +20,7 @@
 
 import re
 
-from .core import CoqText, RichSentence, CoqMessages, CoqGoals
+from .core import Text, RichSentence, Messages, Goals
 from . import transforms, GENERATOR
 
 def format_macro(name, args, optargs):
@@ -54,7 +54,7 @@ class Context:
 
     def add(self, child):
         if isinstance(child, str):
-            child = Text(child)
+            child = PlainText(child)
         self.children.append(child)
         self.claim(child)
 
@@ -135,7 +135,7 @@ class Raw:
     def format(self, indent, verbatim):
         return self.raw_format(self.s, indent, verbatim)
 
-class Text(Raw):
+class PlainText(Raw):
     ESCAPES = Replacements({"\\": "\\bsl"}) # FIXME # Use pygments directly?
 
     def format(self, indent, verbatim):
@@ -177,7 +177,7 @@ class LatexGenerator:
     def gen_whitespace(wsps):
         # Unlike in HTML, we don't need a separate wsp environment
         for wsp in wsps:
-            yield Text(wsp)
+            yield PlainText(wsp)
 
     def gen_input(self, fr):
         contents = []
@@ -195,12 +195,12 @@ class LatexGenerator:
     def gen_output(self, fr):
         with environments.output():
             for output in fr.outputs:
-                if isinstance(output, CoqMessages):
+                if isinstance(output, Messages):
                     assert output.messages, "transforms.commit_io_annotations"
                     with environments.messages():
                         for message in output.messages:
                             environments.message(*self.highlight(message.contents), verbatim=True)
-                if isinstance(output, CoqGoals):
+                if isinstance(output, Goals):
                     assert output.goals, "transforms.commit_io_annotations"
                     with environments.goals():
                         self.gen_goals(output.goals[0], output.goals[1:])
@@ -213,7 +213,7 @@ class LatexGenerator:
                 self.gen_output(fr)
 
     def gen_fragment(self, fr):
-        if isinstance(fr, CoqText):
+        if isinstance(fr, Text):
             if fr.contents:
                 environments.txt(*self.highlight(fr.contents), verbatim=True)
         else:

--- a/assets/alectryon.css
+++ b/assets/alectryon.css
@@ -41,12 +41,12 @@ SOFTWARE.
 
 /* Undo <small> and <blockquote>, added to improve RSS rendering. */
 
-.alectryon-io small.coq-output {
+.alectryon-io small.alectryon-output {
     font-size: inherit;
 }
 
-.alectryon-io blockquote.coq-goal,
-.alectryon-io blockquote.coq-message {
+.alectryon-io blockquote.alectryon-goal,
+.alectryon-io blockquote.alectryon-message {
     font-weight: normal;
     font-size: inherit;
 }
@@ -90,37 +90,37 @@ In any case, make an exception for comments:
 */
 
 .alectryon-toggle,
-.alectryon-io .coq-toggle,
-.alectryon-io .coq-extra-goal-toggle {
+.alectryon-io .alectryon-toggle,
+.alectryon-io .alectryon-extra-goal-toggle {
     display: none;
 }
 
 .alectryon-bubble,
 .alectryon-toggle-label,
-.alectryon-io label.coq-input,
-.alectryon-io .coq-extra-goal-label {
+.alectryon-io label.alectryon-input,
+.alectryon-io .alectryon-extra-goal-label {
     cursor: pointer;
 }
 
 .alectryon-toggle-label,
-.coq-extra-goal-label {
+.alectryon-extra-goal-label {
     display: block;
     font-size: 0.8rem;
 }
 
-.alectryon-io .coq-input {
+.alectryon-io .alectryon-input {
     padding: 0.1em 0; /* Enlarge the hitbox slightly to fill interline gaps */
 }
 
-.alectryon-io .coq-sentence.alectryon-target .coq-input {
+.alectryon-io .alectryon-sentence.alectryon-target .alectryon-input {
     /* FIXME if keywords were ‘bolder’ we wouldn't need !important */
     font-weight: bold !important; /* Use !important to avoid a * selector */
 }
 
 .alectryon-bubble:before,
 .alectryon-toggle-label:before,
-.alectryon-io label.coq-input:after,
-.alectryon-io .coq-extra-goal-label:before {
+.alectryon-io label.alectryon-input:after,
+.alectryon-io .alectryon-extra-goal-label:before {
     border: 1px solid #babdb6;
     border-radius: 1rem;
     box-sizing: border-box;
@@ -134,19 +134,19 @@ In any case, make an exception for comments:
 }
 
 .alectryon-toggle-label:before,
-.alectryon-io .coq-extra-goal-label:before {
+.alectryon-io .alectryon-extra-goal-label:before {
     margin-right: 0.25rem;
 }
 
-.alectryon-io .coq-extra-goal-label::before {
+.alectryon-io .alectryon-extra-goal-label::before {
     margin-top: -0.35rem;
 }
 
-.alectryon-io label.coq-input {
+.alectryon-io label.alectryon-input {
     padding-right: 1rem; /* Prevent line wraps before the checkbox bubble */
 }
 
-.alectryon-io label.coq-input:after {
+.alectryon-io label.alectryon-input:after {
     margin-left: 0.25rem;
     margin-right: -1rem; /* Compensate for the anti-wrapping space */
 }
@@ -169,40 +169,40 @@ In any case, make an exception for comments:
 @media (any-hover: hover) {
     .alectryon-bubble:hover:before,
     .alectryon-toggle-label:hover:before,
-    .alectryon-io label.coq-input:hover:after {
+    .alectryon-io label.alectryon-input:hover:after {
         background: #eeeeec;
     }
 
-    .alectryon-io label.coq-input:hover {
+    .alectryon-io label.alectryon-input:hover {
         text-decoration: underline dotted #babdb6;
 	    text-shadow: 0 0 1px rgb(46, 52, 54, 0.3); /* #2e3436 + opacity */
     }
 
-    .alectryon-io .coq-sentence:hover .coq-output {
-        z-index: 2; /* Place hovered goals above .coq-sentence.alectryon-target ones */
+    .alectryon-io .alectryon-sentence:hover .alectryon-output {
+        z-index: 2; /* Place hovered goals above .alectryon-sentence.alectryon-target ones */
     }
 }
 
 .alectryon-toggle:checked + .alectryon-toggle-label:before,
-.alectryon-io .coq-toggle:checked + label.coq-input:after,
-.alectryon-io .coq-extra-goal-toggle:checked + .coq-goal .coq-extra-goal-label:before {
+.alectryon-io .alectryon-toggle:checked + label.alectryon-input:after,
+.alectryon-io .alectryon-extra-goal-toggle:checked + .alectryon-goal .alectryon-extra-goal-label:before {
     background-color: #babdb6;
     border-color: #babdb6;
 }
 
 /* Disable clicks on sentences when the document-wide toggle is set. */
-.alectryon-toggle:checked + label + .alectryon-container label.coq-input {
+.alectryon-toggle:checked + label + .alectryon-container label.alectryon-input {
     cursor: unset;
     pointer-events: none;
 }
 
 /* Hide individual checkboxes when the document-wide toggle is set. */
-.alectryon-toggle:checked + label + .alectryon-container label.coq-input:after {
+.alectryon-toggle:checked + label + .alectryon-container label.alectryon-input:after {
     display: none;
 }
 
-/* .coq-output is displayed by toggles, :hover, and .alectryon-target rules */
-.alectryon-io .coq-output {
+/* .alectryon-output is displayed by toggles, :hover, and .alectryon-target rules */
+.alectryon-io .alectryon-output {
     box-sizing: border-box;
     display: none;
     left: 0;
@@ -214,28 +214,28 @@ In any case, make an exception for comments:
 }
 
 @media (any-hover: hover) { /* See note above about this @media query */
-    .alectryon-io .coq-sentence:hover .coq-output:not(:hover) {
+    .alectryon-io .alectryon-sentence:hover .alectryon-output:not(:hover) {
         display: block;
     }
 }
 
-.alectryon-io .coq-sentence.alectryon-target .coq-output {
+.alectryon-io .alectryon-sentence.alectryon-target .alectryon-output {
     display: block;
 }
 
 /* Indicate active (hovered or targeted) goals with a shadow. */
-.alectryon-io .coq-sentence:hover .coq-output:not(:hover) .coq-messages,
-.alectryon-io .coq-sentence.alectryon-target .coq-output  .coq-messages,
-.alectryon-io .coq-sentence:hover .coq-output:not(:hover) .coq-goals,
-.alectryon-io .coq-sentence.alectryon-target .coq-output  .coq-goals {
+.alectryon-io .alectryon-sentence:hover .alectryon-output:not(:hover) .alectryon-messages,
+.alectryon-io .alectryon-sentence.alectryon-target .alectryon-output  .alectryon-messages,
+.alectryon-io .alectryon-sentence:hover .alectryon-output:not(:hover) .alectryon-goals,
+.alectryon-io .alectryon-sentence.alectryon-target .alectryon-output  .alectryon-goals {
     box-shadow: 0 0 3px gray;
 }
 
-.alectryon-io .coq-extra-goals .coq-goal .goal-hyps {
+.alectryon-io .alectryon-extra-goals .alectryon-goal .goal-hyps {
     display: none;
 }
 
-.alectryon-io .coq-extra-goals .coq-extra-goal-toggle:not(:checked) + .coq-goal label.goal-separator hr {
+.alectryon-io .alectryon-extra-goals .alectryon-extra-goal-toggle:not(:checked) + .alectryon-goal label.goal-separator hr {
     /* Dashes indicate that the hypotheses are hidden */
     border-top-style: dashed;
 }
@@ -243,7 +243,7 @@ In any case, make an exception for comments:
 
 /* Show just a small preview of the other goals; this is undone by the
    "extra-goal" toggle and by :hover and .alectryon-target in windowed mode. */
-.alectryon-io .coq-extra-goals .coq-goal .goal-conclusion {
+.alectryon-io .alectryon-extra-goals .alectryon-goal .goal-conclusion {
     max-height: 5.2em;
     overflow-y: auto;
     /* Combining ‘overflow-y: auto’ with ‘display: inline-block’ causes extra space
@@ -251,15 +251,15 @@ In any case, make an exception for comments:
     vertical-align: middle;
 }
 
-.alectryon-io .coq-goals,
-.alectryon-io .coq-messages {
+.alectryon-io .alectryon-goals,
+.alectryon-io .alectryon-messages {
     background: #eeeeec;
 	border: thin solid #d3d7cf; /* Convenient when pre's background is already #EEE */
     display: block;
     padding: 0.25rem;
 }
 
-.coq-message::before {
+.alectryon-message::before {
     content: '';
     float: right;
     /* etc/svg/square-bubble-xl.svg */
@@ -273,8 +273,8 @@ In any case, make an exception for comments:
 }
 
 /* Show goals when a toggle is set */
-.alectryon-toggle:checked + label + .alectryon-container label.coq-input + .coq-output,
-.alectryon-io .coq-sentence .coq-toggle:checked ~ .coq-output {
+.alectryon-toggle:checked + label + .alectryon-container label.alectryon-input + .alectryon-output,
+.alectryon-io .alectryon-sentence .alectryon-toggle:checked ~ .alectryon-output {
     display: block;
     position: static;
     width: unset;
@@ -282,48 +282,48 @@ In any case, make an exception for comments:
     padding: 0.25rem 0; /* Re-assert so that later :hover rules don't override this padding */
 }
 
-.alectryon-toggle:checked + label + .alectryon-container label.coq-input + .coq-output .goal-hyps,
-.alectryon-io .coq-toggle:checked ~ .coq-output .goal-hyps {
+.alectryon-toggle:checked + label + .alectryon-container label.alectryon-input + .alectryon-output .goal-hyps,
+.alectryon-io .alectryon-toggle:checked ~ .alectryon-output .goal-hyps {
     /* Overridden back in windowed style */
     flex-flow: row wrap;
     justify-content: flex-start;
 }
 
-.alectryon-toggle:checked + label + .alectryon-container .coq-sentence .coq-output > .coq-output-sticky-wrapper,
-.alectryon-io .coq-sentence .coq-toggle:checked ~ .coq-output > .coq-output-sticky-wrapper {
+.alectryon-toggle:checked + label + .alectryon-container .alectryon-sentence .alectryon-output > .alectryon-output-sticky-wrapper,
+.alectryon-io .alectryon-sentence .alectryon-toggle:checked ~ .alectryon-output > .alectryon-output-sticky-wrapper {
     display: block;
 }
 
-.alectryon-io .coq-extra-goal-toggle:checked + .coq-goal .goal-hyps {
+.alectryon-io .alectryon-extra-goal-toggle:checked + .alectryon-goal .goal-hyps {
     display: flex;
 }
 
-.alectryon-io .coq-extra-goal-toggle:checked + .coq-goal .goal-conclusion {
+.alectryon-io .alectryon-extra-goal-toggle:checked + .alectryon-goal .goal-conclusion {
     max-height: unset;
     overflow-y: unset;
 }
 
-.alectryon-toggle:checked + label + .alectryon-container .coq-toggle ~ .coq-wsp,
-.alectryon-io .coq-toggle:checked ~ .coq-wsp {
+.alectryon-toggle:checked + label + .alectryon-container .alectryon-toggle ~ .alectryon-wsp,
+.alectryon-io .alectryon-toggle:checked ~ .alectryon-wsp {
     display: none;
 }
 
-.alectryon-io .coq-messages,
-.alectryon-io .coq-message,
-.alectryon-io .coq-goals,
-.alectryon-io .coq-goal,
+.alectryon-io .alectryon-messages,
+.alectryon-io .alectryon-message,
+.alectryon-io .alectryon-goals,
+.alectryon-io .alectryon-goal,
 .alectryon-io .goal-hyp,
 .alectryon-io .goal-conclusion {
     border-radius: 0.15rem;
 }
 
-.alectryon-io .coq-goal,
-.alectryon-io .coq-message {
+.alectryon-io .alectryon-goal,
+.alectryon-io .alectryon-message {
     margin: 0.25rem;
 }
 
-.alectryon-io .coq-goal,
-.alectryon-io .coq-message {
+.alectryon-io .alectryon-goal,
+.alectryon-io .alectryon-message {
     align-items: center;
     background: #d3d7cf;
     display: block;
@@ -439,8 +439,8 @@ In any case, make an exception for comments:
        when they are both :checked and -targeted, since it gets confusing as
        things jump around; hence the commented-output part of the selector,
        which would otherwise increase specificity */
-    .alectryon-floating .coq-sentence.alectryon-target /* .coq-toggle ~ */ .coq-output,
-    .alectryon-floating .coq-sentence:hover .coq-output {
+    .alectryon-floating .alectryon-sentence.alectryon-target /* .alectryon-toggle ~ */ .alectryon-output,
+    .alectryon-floating .alectryon-sentence:hover .alectryon-output {
         top: 0;
         left: 100%;
         right: -100%;
@@ -448,37 +448,37 @@ In any case, make an exception for comments:
         position:  absolute;
     }
 
-    .alectryon-floating .coq-output {
+    .alectryon-floating .alectryon-output {
         min-height: 100%;
     }
 
-    .alectryon-floating .coq-sentence:hover .coq-output {
+    .alectryon-floating .alectryon-sentence:hover .alectryon-output {
         background: white; /* Ensure that short goals hide long ones */
     }
 
     /* This odd margin-bottom property prevents the sticky div from bumping
-       against the bottom of its container (.coq-output).  The alternative
-       would be enlarging .coq-output, but that would cause overflows,
+       against the bottom of its container (.alectryon-output).  The alternative
+       would be enlarging .alectryon-output, but that would cause overflows,
        enlarging scrollbars and yielding scrolling towards the bottom of the
        page.  Doing things this way instead makes it possible to restrict
-       .coq-output to a reasonable size (100%, through top = bottom = 0).
+       .alectryon-output to a reasonable size (100%, through top = bottom = 0).
        See also https://stackoverflow.com/questions/43909940/. */
     /* See note on specificity above */
-    .alectryon-floating .coq-sentence.alectryon-target /* .coq-toggle ~ */ .coq-output .coq-output-sticky-wrapper,
-    .alectryon-floating .coq-sentence:hover .coq-output-sticky-wrapper {
+    .alectryon-floating .alectryon-sentence.alectryon-target /* .alectryon-toggle ~ */ .alectryon-output .alectryon-output-sticky-wrapper,
+    .alectryon-floating .alectryon-sentence:hover .alectryon-output-sticky-wrapper {
         margin-bottom: -200%;
         position: sticky;
         top: 0;
     }
 
-    .alectryon-floating .alectryon-toggle:checked + label + .alectryon-container .coq-sentence .coq-output > .coq-output-sticky-wrapper,
-    .alectryon-floating .alectryon-io .coq-sentence .coq-toggle:checked ~ .coq-output > .coq-output-sticky-wrapper {
+    .alectryon-floating .alectryon-toggle:checked + label + .alectryon-container .alectryon-sentence .alectryon-output > .alectryon-output-sticky-wrapper,
+    .alectryon-floating .alectryon-io .alectryon-sentence .alectryon-toggle:checked ~ .alectryon-output > .alectryon-output-sticky-wrapper {
         margin-bottom: unset; /* Undo the margin */
     }
 
     /* Float underneath the current fragment
     @media (max-width: 80rem) {
-        .alectryon-floating .coq-output {
+        .alectryon-floating .alectryon-output {
             top: 100%;
         }
     } */
@@ -493,42 +493,42 @@ In any case, make an exception for comments:
     box-sizing: border-box;
 }
 
-.alectryon-windowed .coq-sentence:hover .coq-output {
+.alectryon-windowed .alectryon-sentence:hover .alectryon-output {
     background: white; /* Ensure that short goals hide long ones */
 }
 
-.alectryon-windowed .coq-output {
+.alectryon-windowed .alectryon-output {
     position: fixed; /* Overwritten by the ‘:checked’ rules */
 }
 
 /* See note about specificity below */
-.alectryon-windowed .coq-sentence:hover .coq-output,
-.alectryon-windowed .coq-sentence.alectryon-target .coq-toggle ~ .coq-output {
+.alectryon-windowed .alectryon-sentence:hover .alectryon-output,
+.alectryon-windowed .alectryon-sentence.alectryon-target .alectryon-toggle ~ .alectryon-output {
     padding: 0.5rem;
     overflow-y: auto; /* Windowed contents may need to scroll */
 }
 
-.alectryon-windowed .alectryon-io .coq-sentence:hover .coq-output:not(:hover) .coq-messages,
-.alectryon-windowed .alectryon-io .coq-sentence.alectryon-target .coq-output  .coq-messages,
-.alectryon-windowed .alectryon-io .coq-sentence:hover .coq-output:not(:hover) .coq-goals,
-.alectryon-windowed .alectryon-io .coq-sentence.alectryon-target .coq-output  .coq-goals {
+.alectryon-windowed .alectryon-io .alectryon-sentence:hover .alectryon-output:not(:hover) .alectryon-messages,
+.alectryon-windowed .alectryon-io .alectryon-sentence.alectryon-target .alectryon-output  .alectryon-messages,
+.alectryon-windowed .alectryon-io .alectryon-sentence:hover .alectryon-output:not(:hover) .alectryon-goals,
+.alectryon-windowed .alectryon-io .alectryon-sentence.alectryon-target .alectryon-output  .alectryon-goals {
     box-shadow: none; /* A shadow is unnecessary here and incompatible with overflow-y set to auto */
 }
 
-.alectryon-windowed .alectryon-io .coq-sentence.alectryon-target .coq-output .goal-hyps {
+.alectryon-windowed .alectryon-io .alectryon-sentence.alectryon-target .alectryon-output .goal-hyps {
     /* Restated to override the :checked style */
     flex-flow: column nowrap;
     justify-content: space-around;
 }
 
 
-.alectryon-windowed .coq-sentence.alectryon-target .coq-extra-goals .coq-goal .goal-conclusion
-/* Like .alectryon-io .coq-extra-goal-toggle:checked + .coq-goal .goal-conclusion */ {
+.alectryon-windowed .alectryon-sentence.alectryon-target .alectryon-extra-goals .alectryon-goal .goal-conclusion
+/* Like .alectryon-io .alectryon-extra-goal-toggle:checked + .alectryon-goal .goal-conclusion */ {
     max-height: unset;
     overflow-y: unset;
 }
 
-.alectryon-windowed .coq-output-sticky-wrapper {
+.alectryon-windowed .alectryon-output-sticky-wrapper {
     display: flex; /* Put messages after goals */
     flex-direction: column-reverse;
 }
@@ -616,7 +616,7 @@ In any case, make an exception for comments:
    goals to appear in consistent locations).  The selectors below ensure
    that :hover < :checked < -targeted in terms of specificity. */
 /* LATER: Reimplement this stuff with CSS variables */
-.alectryon-windowed .coq-sentence.alectryon-target .coq-toggle ~ .coq-output {
+.alectryon-windowed .alectryon-sentence.alectryon-target .alectryon-toggle ~ .alectryon-output {
     position: fixed;
 }
 
@@ -629,8 +629,8 @@ In any case, make an exception for comments:
         top: 0;
     }
 
-    .alectryon-standalone .alectryon-windowed .coq-sentence:hover .coq-output,
-    .alectryon-standalone .alectryon-windowed .coq-sentence.alectryon-target .coq-output {
+    .alectryon-standalone .alectryon-windowed .alectryon-sentence:hover .alectryon-output,
+    .alectryon-standalone .alectryon-windowed .alectryon-sentence.alectryon-target .alectryon-output {
         bottom: 0;
         left: 50%;
         right: 0;
@@ -647,8 +647,8 @@ In any case, make an exception for comments:
         top: 0;
     }
 
-    .alectryon-standalone .alectryon-windowed .coq-sentence:hover .coq-output,
-    .alectryon-standalone .alectryon-windowed .coq-sentence.alectryon-target .coq-output {
+    .alectryon-standalone .alectryon-windowed .alectryon-sentence:hover .alectryon-output,
+    .alectryon-standalone .alectryon-windowed .alectryon-sentence.alectryon-target .alectryon-output {
         bottom: 0;
         left: 0;
         right: 0;

--- a/assets/alectryon.js
+++ b/assets/alectryon.js
@@ -108,7 +108,7 @@ var Alectryon;
                 var sentence = evt.currentTarget;
 
                 // Ensure that the goal is shown on the side, not inline
-                var checkbox = sentence.getElementsByClassName("coq-toggle")[0];
+                var checkbox = sentence.getElementsByClassName("alectryon-toggle")[0];
                 if (checkbox)
                     checkbox.checked = false;
 
@@ -120,7 +120,7 @@ var Alectryon;
         function init() {
             document.onkeydown = onkeydown;
             slideshow.pos = -1;
-            slideshow.sentences = Array.from(document.getElementsByClassName("coq-sentence"));
+            slideshow.sentences = Array.from(document.getElementsByClassName("alectryon-sentence"));
             slideshow.sentences.forEach(function (s, idx) {
                 s.addEventListener('click', handleClick, false);
                 s.alectryon_index = idx;


### PR DESCRIPTION
I'm planning to start porting Alectryon to work with other proof assistants soon, and having everything named after Coq isn't ideal for that, so I'm making that change before too many people depend on these class names.

Making it into a PR so that the relevant people can adjust to the change.  Will merge in a week or so.