### PR TITLE
cli: Invoke coqdoc in a temporary directory

### DIFF
--- a/recipes/.gitignore
+++ b/recipes/.gitignore
@@ -1,3 +1,2 @@
 /output/*.css
 /output/*.js
-coqdoc.css


### PR DESCRIPTION
Coqdoc writes coqdoc.css unconditionally in its cwd, so invoke it
from a temporary directory.

Fixes GH-16.