### PR TITLE
Add support for Cmd key on Mac

### DIFF
--- a/alectryon/html.py
+++ b/alectryon/html.py
@@ -72,7 +72,8 @@ HEADER = (
     'Built with <a href="https://github.com/cpitclaudel/alectryon/">Alectryon</a>, running {}. '
     'Coq sources are in this panel; goals and messages will appear in the other. '
     'Bubbles (<span class="alectryon-bubble"></span>) indicate interactive fragments: hover for details, tap to reveal contents. '
-    'Use <kbd>Ctrl+↑</kbd> <kbd>Ctrl+↓</kbd> to navigate, <kbd>Ctrl+🖱️</kbd> to focus.'
+    'Use <kbd>Ctrl+↑</kbd> <kbd>Ctrl+↓</kbd> to navigate, <kbd>Ctrl+🖱️</kbd> to focus. '
+    'On Mac, use <kbd>Cmd</kbd> instead of <kbd>Ctrl</kbd>.'
     '</div>'
 )
 

--- a/assets/alectryon.js
+++ b/assets/alectryon.js
@@ -74,7 +74,7 @@ var Alectryon;
 
         function onkeydown(e) {
             e = e || window.event;
-            if (e.ctrlKey) {
+            if (e.ctrlKey || e.metaKey) {
                 if (e.keyCode == keys.ARROW_UP)
                     slideshow.previous();
                 else if (e.keyCode == keys.ARROW_DOWN)


### PR DESCRIPTION
Previously, neither the control key nor the `Cmd` key worked to step through Alectryon proofs on Mac. This change adds `e.metaKey` to pick up the `Cmd` key on Mac, and adds a line to the instructions telling Mac users to use `Cmd`.