### PR TITLE
Add preamble and copy assets

### DIFF
--- a/alectryon/assets/alectryon.sty
+++ b/alectryon/assets/alectryon.sty
@@ -120,8 +120,8 @@
 \newcommand{\alectryon@copymacro}[1]
   {\expandafter\def\csname #1\endcsname{\csname alectryon@#1\endcsname}}
 \newcommand{\alectryon@copyenvironment}[1]
-  {\expandafter\def\csname #1\endcsname{\begin{alectryon@#1}}%
-   \expandafter\def\csname end#1\endcsname{\end{alectryon@#1}}}
+  {\expandafter\def\csname #1\endcsname{\csname alectryon@#1\endcsname}%
+   \expandafter\def\csname end#1\endcsname{\csname endalectryon@#1\endcsname}}
 
 \newenvironment{alectryon}
   {\alectryon@copyenvironment{txt}

--- a/alectryon/docutils.py
+++ b/alectryon/docutils.py
@@ -78,8 +78,8 @@ from docutils.writers import get_writer_class
 
 from . import transforms
 from .core import annotate, SerAPI, GeneratorInfo
-from .html import ASSETS, ADDITIONAL_HEADS, HtmlGenerator, gen_banner, wrap_classes
-from .latex import LatexGenerator
+from .html import ADDITIONAL_HEADS, HtmlGenerator, gen_banner, wrap_classes, ASSETS as ASSETS_HTML
+from .latex import LatexGenerator, ASSETS as ASSETS_LATEX
 from .pygments import highlight_html, highlight_latex, added_tokens, replace_builtin_coq_lexer
 
 # reST extensions
@@ -557,9 +557,9 @@ class RSTCoqStandaloneReader(Reader):
 DefaultHtmlWriter = get_writer_class('html')
 
 class HtmlTranslator(DefaultHtmlWriter().translator_class):
-    JS = ASSETS.ALECTRYON_JS
-    CSS = (*ASSETS.ALECTRYON_CSS, *ASSETS.DOCUTILS_CSS, *ASSETS.PYGMENTS_CSS)
-    ADDITIONAL_HEADS = [ASSETS.IBM_PLEX_CDN, ASSETS.FIRA_CODE_CDN, *ADDITIONAL_HEADS]
+    JS = ASSETS_HTML.ALECTRYON_JS
+    CSS = (*ASSETS_HTML.ALECTRYON_CSS, *ASSETS_HTML.DOCUTILS_CSS, *ASSETS_HTML.PYGMENTS_CSS)
+    ADDITIONAL_HEADS = [ASSETS_HTML.IBM_PLEX_CDN, ASSETS_HTML.FIRA_CODE_CDN, *ADDITIONAL_HEADS]
 
     JS_TEMPLATE = '<script type="text/javascript" src="{}"></script>\n'
     MATHJAX_URL = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.1.2/es5/tex-mml-chtml.min.js"
@@ -570,7 +570,7 @@ class HtmlTranslator(DefaultHtmlWriter().translator_class):
     def stylesheet_call(self, name):
         if self.settings.embed_stylesheet:
             # Expand only if we're going to inline; otherwise keep relative
-            name = os.path.join(ASSETS.PATH, name)
+            name = os.path.join(ASSETS_HTML.PATH, name)
         return super().stylesheet_call(name)
 
     def __init__(self, document):
@@ -621,8 +621,13 @@ class HtmlWriter(DefaultHtmlWriter):
 DefaultLatexWriter = get_writer_class('latex')
 
 class LatexTranslator(DefaultLatexWriter().translator_class):
-    pass
-    # FIXME: handle options (as done in ``HtmlTranslator``), add preamble
+    STY = ASSETS_LATEX.ALECTRYON_STY + ASSETS_LATEX.PYGMENTS_STY
+
+    def __init__(self, document):
+        document.settings.font_encoding = ''
+        document.settings.latex_preamble = ''
+        document.settings.stylesheet_path = ','.join(self.STY)
+        super().__init__(document)
 
 class LatexWriter(DefaultLatexWriter):
     settings_spec = ('Latex-Specific Options', None,

--- a/alectryon/html.py
+++ b/alectryon/html.py
@@ -19,8 +19,7 @@
 # SOFTWARE.
 
 from collections import defaultdict
-from os import path, unlink
-import shutil
+from os import path
 
 from dominate import tags
 
@@ -44,22 +43,6 @@ class ASSETS:
 
     IBM_PLEX_CDN = '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/IBM-type/0.5.4/css/ibm-type.min.css" integrity="sha512-sky5cf9Ts6FY1kstGOBHSybfKqdHR41M0Ldb0BjNiv3ifltoQIsg0zIaQ+wwdwgQ0w9vKFW7Js50lxH9vqNSSw==" crossorigin="anonymous" />'
     FIRA_CODE_CDN = '<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/firacode/5.2.0/fira_code.min.css" integrity="sha512-MbysAYimH1hH2xYzkkMHB6MqxBqfP0megxsCLknbYqHVwXTCg9IqHbk+ZP/vnhO8UEW6PaXAkKe2vQ+SWACxxA==" crossorigin="anonymous" />'
-
-def copy_assets(output_directory,
-                assets=ASSETS.ALECTRYON_CSS + ASSETS.ALECTRYON_JS,
-                copy_fn=shutil.copy):
-    for name in assets:
-        src = path.join(ASSETS.PATH, name)
-        dst = path.join(output_directory, name)
-        if copy_fn is not shutil.copy:
-            try:
-                unlink(dst)
-            except FileNotFoundError:
-                pass
-        try:
-            copy_fn(src, dst)
-        except shutil.SameFileError:
-            pass
 
 class Gensym():
     def __init__(self, stem):

--- a/alectryon/latex.py
+++ b/alectryon/latex.py
@@ -69,6 +69,10 @@ class Context:
     def format(self, indent, verbatim):
         raise NotImplementedError()
 
+    def render(self, pretty=False): # pylint: disable=unused-argument
+        # For compatibility with the HTML backend (dominate)
+        return str(self)
+
     def __str__(self):
         return self.format(indent=0, verbatim=False)
 

--- a/alectryon/latex.py
+++ b/alectryon/latex.py
@@ -144,7 +144,8 @@ class Raw:
         return self.raw_format(self.s, indent, verbatim)
 
 class PlainText(Raw):
-    ESCAPES = Replacements({"\\": "\\bsl"}) # FIXME # Use pygments directly?
+    ESCAPES = Replacements({ c: r"\char`\{}".format(c)
+                             for c in '\\{}&^$">-<%#\'~_' })
 
     def format(self, indent, verbatim):
         return self.raw_format(self.ESCAPES(self.s), indent, verbatim)
@@ -161,7 +162,10 @@ macros = Macros()
 
 class LatexGenerator:
     def __init__(self, highlighter):
-        self.highlight = lambda s: [Raw(highlighter(s, prefix="", suffix=""))]
+        self.highlighter = highlighter
+
+    def highlight(self, s):
+        return [Raw(self.highlighter(s, prefix="", suffix=""))]
 
     def gen_goal(self, goal):
         """Serialize a goal to LaTeX."""

--- a/alectryon/latex.py
+++ b/alectryon/latex.py
@@ -23,6 +23,10 @@ import re
 from .core import Text, RichSentence, Messages, Goals
 from . import transforms, GENERATOR
 
+class ASSETS:
+    PYGMENTS_STY = ("tango_subtle.sty",)
+    ALECTRYON_STY = ("alectryon.sty",)
+
 def format_macro(name, args, optargs):
     args = "".join("{" + str(arg) + "}" for arg in args)
     optargs = "".join("[" + str(optarg) + "]" for optarg in optargs)

--- a/recipes/Makefile
+++ b/recipes/Makefile
@@ -77,6 +77,14 @@ sphinx/_build/html/index.html: sphinx/index.rst
 output/api.out: api.py
 	$(PYTHON) $< > $@
 
+# LaTeX → PDF
+output/latex.aux:
+	mkdir $@
+
+output/%.pdflatex.pdf: output/%.tex | latex.aux
+	pdflatex -output-directory=output/latex.aux -jobname=$*.pdflatex $<
+	mv output/latex.aux/$*.pdflatex.pdf $@
+
 output/alectryon%css output/alectryon%js: FORCE
 	cp --link --force $(patsubst %,../alectryon/assets/%,$(assets)) output/
 FORCE:

--- a/recipes/Makefile
+++ b/recipes/Makefile
@@ -3,8 +3,20 @@ PYTHON ?= python3
 alectryon := ../alectryon.py --output-directory output --no-version-numbers --traceback
 minimal := $(PYTHON) -m alectryon.minimal
 
-assets := alectryon.css alectryon.js
-all := .version-info plain.v.html literate.v.html coqdoc.v.html coqdoc.html literate.html document.html hyps.html mathjax.html document.minimal.html document.v literate.v.rst fragments.io.json fragments.snippets.html fragments.snippets.tex latex.snippets.tex api.out
+assets := alectryon.css alectryon.js alectryon.sty
+
+all := .version-info \
+	plain.v.html literate.v.html coqdoc.v.html \
+	coqdoc.html \
+	literate.html literate.tex \
+	document.html hyps.html mathjax.html \
+	document.tex hyps.tex \
+	document.minimal.html \
+	document.v literate.v.rst \
+	fragments.io.json \
+	fragments.snippets.html fragments.snippets.tex \
+	latex.snippets.tex \
+	api.out
 
 all: $(patsubst %,output/%,$(all) $(assets)) sphinx/_build/html/index.html;
 
@@ -25,6 +37,14 @@ output/literate.v.html: literate.v | output
 output/coqdoc.v.html: coqdoc.v | output
 	$(alectryon) --frontend coq $<
 
+# No plain Coq → LaTeX for now
+# output/plain.v.tex: plain.v | output
+# 	$(alectryon) --frontend coq --backend latex $<
+# output/literate.v.tex: literate.v | output
+# 	$(alectryon) --frontend coq --backend latex $<
+# output/coqdoc.v.tex: coqdoc.v | output
+# 	$(alectryon) --frontend coq --backend latex $<
+
 # Coqdoc → HTML
 output/coqdoc.html: coqdoc.v | output
 	$(alectryon) $< --frontend coqdoc
@@ -33,6 +53,10 @@ output/coqdoc.html: coqdoc.v | output
 output/literate.html: literate.v | output
 	$(alectryon) $<
 
+# Coq+reST → LaTeX
+output/literate.tex: literate.v | output
+	$(alectryon) --backend latex $<
+
 # reST+Coq → HTML
 output/document.html: document.v.rst | output
 	$(alectryon) $<
@@ -40,6 +64,16 @@ output/hyps.html: hyps.rst | output
 	$(alectryon) $<
 output/mathjax.html: mathjax.rst | output
 	$(alectryon) $<
+
+# reST+Coq → LaTeX
+output/document.tex: document.v.rst | output
+	$(alectryon) --backend latex $<
+output/hyps.tex: hyps.rst | output
+	$(alectryon) --backend latex $<
+
+# FIXME
+# output/mathjax.html: mathjax.rst | output
+# 	$(alectryon) --backend latex $<
 
 # Minimal reST+Coq → HTML
 output/document.minimal.html: document.v.rst | output
@@ -85,7 +119,7 @@ output/%.pdflatex.pdf: output/%.tex | latex.aux
 	pdflatex -output-directory=output/latex.aux -jobname=$*.pdflatex $<
 	mv output/latex.aux/$*.pdflatex.pdf $@
 
-output/alectryon%css output/alectryon%js: FORCE
+output/alectryon%css output/alectryon%js output/alectryon%sty: FORCE
 	cp --link --force $(patsubst %,../alectryon/assets/%,$(assets)) output/
 FORCE:
 


### PR DESCRIPTION
I have added preamble to use package style "alectryon.sty" and "tango_subtle.sty".
And I add a copy of their assets styles files associate to destination.


I cannot compile the PDF associate, for this latex. I mean, we need to remove docutils packages imported, but I can't found this options in documentation.
