### PR TITLE
feat(docutils): Use `section_self_link` (needs html5 + CSS update)

### DIFF
--- a/alectryon/assets/docutils_basic.css
+++ b/alectryon/assets/docutils_basic.css
@@ -74,6 +74,18 @@ span.section-subtitle {
     font-size: 80%,
 }
 
+a.self-link {
+  text-decoration: none;
+}
+
+*:hover > a.self-link:after {
+  text-decoration: none;
+  content: "\1F517"; /* LINK SYMBOL */
+  color: grey;
+  font-size: smaller;
+  margin-left: 0.2em;
+}
+
 /* //-------- Headings ---------- */
 
 

--- a/alectryon/cli.py
+++ b/alectryon/cli.py
@@ -774,7 +774,7 @@ and produce reStructuredText, HTML, LaTeX, or JSON output.""",
 
     HTML_DIALECT_HELP = "Choose which HTML dialect to use."
     HTML_DIALECT_CHOICES = ("html4", "html5")
-    html_out.add_argument("--html-dialect", default="html4",
+    html_out.add_argument("--html-dialect", default="html5",
                           choices=HTML_DIALECT_CHOICES,
                           help=HTML_DIALECT_HELP)
 


### PR DESCRIPTION
I recently noticed that despite the availability of this new feature in docutils: https://sourceforge.net/p/docutils/feature-requests/28/
(which BTW can only be enabled **in HTML5**), the feature requested in cpitclaudel/alectryon#19 was not yet possible in alectryon.

So, this PR makes it possible to benefit from this feature in Alectryon as well *by default*.

Cc @cpitclaudel