### PR TITLE
setup.cfg: alectryon.__version__ -> alectryon.__init__.__version__

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = alectryon
-version = attr: alectryon.__version__
+version = attr: alectryon.__init__.__version__
 description = A library to process Coq snippets embedded in documents, showing goals and messages for each Coq sentence.
 long_description = file: README.rst
 url = https://github.com/cpitclaudel/alectryon


### PR DESCRIPTION
Fixes build with setuptools>=61.
Huge thanks to Ionen Wolkens (ionenwks) for finding the solution.

Bug: https://bugs.gentoo.org/836748
Signed-off-by: Maciej Barć <xgqt@gentoo.org>