### PR TITLE
port to vsrocq

### DIFF
--- a/alectryon/vsrocq.py
+++ b/alectryon/vsrocq.py
@@ -177,7 +177,7 @@ class VsRocqOutput:
         return Goal(name, conclusion, hypotheses)
 
     @staticmethod
-    def parseproof_view(pv: JSON):
+    def parse_proofview(pv: JSON):
         goals = [VsRocqOutput.parse_goal(gv) for gv in (pv.get("proof") or {}).get("goals", [])]
         return goals
 
@@ -185,14 +185,12 @@ class VsRocqClient(LSPClient):
     LANGUAGE_ID = "coq"
 
 class VsRocqFile(LSPFile[VsRocqClient]):
-    def _compute_ranges(self):
+    def _compute_ranges(self): # FIXME get this info from VSRocq
         req = DocumentStateRequest(self.client, self.uri)
-        document = must(req.send().result)["document"]
-        # parsing with regexes in 2025.. I'll look the other way
-        first_section : str = document.split("Document using sentences_by_end map")[0]
-        first_section = first_section.replace("\n"," ")
+        document: str = must(req.send().result)["document"]
+        first_section: str = document.split("Document using sentences_by_end map")[0]
         PATTERN = re.compile(r"\[\d+\].*?[(](?P<beg>\d+) -> (?P<end>\d+)[)]")
-        for m in PATTERN.finditer(first_section):
+        for m in PATTERN.finditer(first_section.replace("\n"," ")):
             yield int(m.group("beg")), int(m.group("end"))
 
     def process(self) -> Iterable[Positioned[Fragment]]:
@@ -200,7 +198,7 @@ class VsRocqFile(LSPFile[VsRocqClient]):
 
         blocked_on_error: bool = False
         diagnostics: dict[LSPDiagnostic, None] = {}
-        sentences: dict[tuple[int, int], tuple[str,list[Goal]]] = {}
+        sentences: dict[tuple[int, int], tuple[str, list[Goal]]] = {}
         messages: dict[tuple[int, int], list[Message]] = {}
 
         for (beg, end) in self._compute_ranges():
@@ -209,7 +207,7 @@ class VsRocqFile(LSPFile[VsRocqClient]):
                 yield Positioned(beg, end, Text(contents))
                 continue
             pv = StepForwardNotification(self.client, self.fpath, self.uri).send()
-            goals = VsRocqOutput.parseproof_view(must(pv.proof_view))
+            goals = VsRocqOutput.parse_proofview(must(pv.proof_view))
             sentences[(beg,end)] = (contents, goals)
             diagnostics |= dict.fromkeys(pv.diagnostics)
             blocked_on_error |= pv.blocked_on_error

--- a/alectryon/vsrocq.py
+++ b/alectryon/vsrocq.py
@@ -29,12 +29,12 @@ from .lsp import JSON, LSPClient, LSPClientNotification, LSPClientRequest, LSPDi
 from .coq import CoqIdents
 
 class Notifications(LSPServerNotifications):
-    PROOF_VIEW = "vscoq/proofView"
-    BLOCK_ON_ERROR = "vscoq/blockOnError"
+    PROOF_VIEW = "prover/proofView"
+    BLOCK_ON_ERROR = "prover/blockOnError"
 
 @dataclasses.dataclass
 class StepForwardNotification(LSPClientNotification):
-    METHOD = "vscoq/stepForward"
+    METHOD = "prover/stepForward"
     fpath: Path
     uri: str
 
@@ -71,10 +71,10 @@ class URIRequest(LSPClientRequest):
         return { "textDocument": { "uri": self.uri } }
 
 class DocumentProofsRequest(URIRequest):
-    METHOD = "vscoq/documentProofs"
+    METHOD = "prover/documentProofs"
 
 class DocumentStateRequest(URIRequest):
-    METHOD = "vscoq/documentState"
+    METHOD = "prover/documentState"
 
 @dataclasses.dataclass
 class ExponentialBackoff:
@@ -189,7 +189,9 @@ class VsRocqFile(LSPFile[VsRocqClient]):
     def _compute_ranges(self):
         req = DocumentStateRequest(self.client, self.uri)
         document = must(req.send().result)["document"]
-        first_section = document.split("Document using sentences_by_end map")[0]
+        # parsing with regexes in 2025.. I'll look the other way
+        first_section : str = document.split("Document using sentences_by_end map")[0]
+        first_section = first_section.replace("\n"," ")
         PATTERN = re.compile(r"\[\d+\].*?[(](?P<beg>\d+) -> (?P<end>\d+)[)]")
         for m in PATTERN.finditer(first_section):
             yield int(m.group("beg")), int(m.group("end"))
@@ -232,7 +234,7 @@ class VsRocqFile(LSPFile[VsRocqClient]):
         return f"{prefix}>>>{substring}<<<{suffix}"
 
 class VsRocq(LSPDriver[VsRocqClient]):
-    BIN = "vscoqtop"
+    BIN = "vsrocqtop"
     NAME = "VsRocq"
     VERSION_ARGS = ("--version",)
 
@@ -247,7 +249,7 @@ class VsRocq(LSPDriver[VsRocqClient]):
         return CoqIdents.toppath_of_fpath(p)
 
     def _encode(self, chunks: Iterable[str]) -> Document:
-        # FIXME: VsRocq sends vscoq/documentState info using utf-8 offsets but
+        # FIXME: VsRocq sends prover/documentState info using utf-8 offsets but
         # uses codepoints (instead of utf-16?) in diagnostic line/char pairs.
         return UTF8Document(chunks, "\n")
 

--- a/alectryon/vsrocq.py
+++ b/alectryon/vsrocq.py
@@ -178,9 +178,8 @@ class VsRocqOutput:
 
     @staticmethod
     def parseproof_view(pv: JSON):
-        messages = [VsRocqOutput.parse_message(mv) for mv in pv.get("messages", [])]
         goals = [VsRocqOutput.parse_goal(gv) for gv in (pv.get("proof") or {}).get("goals", [])]
-        return messages, goals
+        return goals
 
 class VsRocqClient(LSPClient):
     LANGUAGE_ID = "coq"
@@ -201,6 +200,8 @@ class VsRocqFile(LSPFile[VsRocqClient]):
 
         blocked_on_error: bool = False
         diagnostics: dict[LSPDiagnostic, None] = {}
+        sentences: dict[tuple[int, int], tuple[str,list[Goal]]] = {}
+        messages: dict[tuple[int, int], list[Message]] = {}
 
         for (beg, end) in self._compute_ranges():
             contents: str = self.doc[beg:end]
@@ -208,18 +209,24 @@ class VsRocqFile(LSPFile[VsRocqClient]):
                 yield Positioned(beg, end, Text(contents))
                 continue
             pv = StepForwardNotification(self.client, self.fpath, self.uri).send()
-            messages, goals = VsRocqOutput.parseproof_view(must(pv.proof_view))
-            yield Positioned(beg, end, Sentence(contents, messages, goals))
+            goals = VsRocqOutput.parseproof_view(must(pv.proof_view))
+            sentences[(beg,end)] = (contents, goals)
             diagnostics |= dict.fromkeys(pv.diagnostics)
             blocked_on_error |= pv.blocked_on_error
 
         # LATER: Adjust line numbers for code blocks embedded in literate documents.
         for diag in diagnostics:
+            beg, end = self.doc.range2offsets(diag.range)
+            messages[(beg,end)] = messages.get((beg,end),[]) + [Message(diag.message)]
             if diag.severity >= 3:
                 continue
-            beg, end = self.doc.range2offsets(diag.range)
             context = self._format_error_context(beg, end)
             diag.notify(self.observer, context)
+
+        for (beg, end) in self._compute_ranges():
+            contents, goals = sentences[(beg,end)]
+            more_messages = messages.get((beg,end), [])
+            yield Positioned(beg, end, Sentence(contents, more_messages, goals))
 
     def _format_error_context(self, beg, end) -> str:
         context = self._highlight_context(beg, end)


### PR DESCRIPTION
Thanks for supporting LSP.
This patch makes it work with vsrocq.
It fixes:
- renaming
- regexp based parsing of sentences ranges
- gathering of messages

The last point is worrying, since the code expects LSP to be synchronous and to emit relevant diagnostics *before* goal view updates. I try to amend this with my maccheroni python, but I'm not so sure.

It seems to works fine on the Elpi tutorials